### PR TITLE
Add packages for 0.49 and 0.50 releases

### DIFF
--- a/Packages/OpenMW/0.49.0/openmw.nuspec
+++ b/Packages/OpenMW/0.49.0/openmw.nuspec
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>openmw</id>
+    <title>OpenMW</title>
+    <version>0.49.0</version>
+    <authors>OpenMW Team</authors>
+    <owners>Alexander "Ace" Olofsson</owners>
+    <summary>OpenMW - Open source Elder Scrolls III: Morrowind engine reimplementation</summary>
+    <description>**OpenMW** is a free, open source and modern engine based which reimplements and extends the one that runs the 2002 open-world RPG Morrowind. The engine comes with its own editor , called **OpenMW-CS** which allows the user to edit or create their own original games. Both OpenMW-CS and OpenMW are written from scratch and aren’t made to support any third party programs the original Morrowind engine uses to improve its functionality.
+
+**NOTE:** Playing Morrowind with this engine still requires the Morrowind data files from a copy that you own.</description>
+    <packageSourceUrl>https://github.com/ananace/chocolatey-packages/</packageSourceUrl>
+    <projectUrl>http://openmw.org</projectUrl>
+    <projectSourceUrl>https://github.com/OpenMW/openmw</projectSourceUrl>
+    <releaseNotes>https://openmw.org/2025/openmw-0-49-0-released/</releaseNotes>
+    <bugTrackerUrl>https://bugs.openmw.org/</bugTrackerUrl>
+    <tags>openmw admin game rpg</tags>
+    <licenseUrl>https://gitlab.com/OpenMW/openmw/-/raw/master/LICENSE</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <iconUrl>https://cdn.rawgit.com/ananace/chocolatey-packages/1adeb04799a706879edc60fcd65dc43dd064674b/Icons/openmw.png</iconUrl>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/Packages/OpenMW/0.49.0/tools/chocolateyinstall.ps1
+++ b/Packages/OpenMW/0.49.0/tools/chocolateyinstall.ps1
@@ -1,0 +1,19 @@
+﻿$ErrorActionPreference = 'Stop';
+
+$packageName = 'openmw'
+
+$packageArgs = @{
+  packageName    = $packageName
+  fileType       = 'exe'
+  url64bit       = 'https://github.com/OpenMW/openmw/releases/download/openmw-0.49.0/OpenMW-0.49.0-win64.exe'
+
+  checksum64     = '150f9c0c3f3d8b925eb50ee66750d1108c7f31749f258132cf6a79436f8e6efe'
+  checksumtype64 = 'sha256'
+
+  silentArgs     = "/S"
+  validExitCodes = @(0)
+
+  registryUninstallerKey = 'OpenMW 0.49.0'
+}
+
+Install-ChocolateyPackage @packageArgs

--- a/Packages/OpenMW/0.49.0/tools/chocolateyuninstall.ps1
+++ b/Packages/OpenMW/0.49.0/tools/chocolateyuninstall.ps1
@@ -1,0 +1,31 @@
+﻿$packageName = 'openmw'
+$registryUninstallerKeyName = 'OpenMW 0.49.0' #ensure this is the value in the registry
+$shouldUninstall = $true
+
+$local_key     = "HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\$registryUninstallerKeyName"
+$local_key6432   = "HKCU:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\$registryUninstallerKeyName" 
+$machine_key   = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$registryUninstallerKeyName"
+$machine_key6432 = "HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\$registryUninstallerKeyName"
+
+$file = @($local_key, $local_key6432, $machine_key, $machine_key6432) `
+    | ?{ Test-Path $_ } `
+    | Get-ItemProperty `
+    | Select-Object -ExpandProperty UninstallString
+
+if ($file -eq $null -or $file -eq '') {
+    Write-Host "$packageName has already been uninstalled by other means."
+    $shouldUninstall = $false
+}
+
+$installerType = 'EXE' 
+$silentArgs = '/S'
+$validExitCodes = @(0)
+
+if (!(Test-Path $file)) {
+    Write-Host "$packageName has already been uninstalled by other means."
+    $shouldUninstall = $false
+}
+
+if ($shouldUninstall) {
+ Uninstall-ChocolateyPackage -PackageName $packageName -FileType $installerType -SilentArgs $silentArgs -validExitCodes $validExitCodes -File $file
+}

--- a/Packages/OpenMW/0.50.0/openmw.nuspec
+++ b/Packages/OpenMW/0.50.0/openmw.nuspec
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>openmw</id>
+    <title>OpenMW</title>
+    <version>0.50.0</version>
+    <authors>OpenMW Team</authors>
+    <owners>Alexander "Ace" Olofsson</owners>
+    <summary>OpenMW - Open source Elder Scrolls III: Morrowind engine reimplementation</summary>
+    <description>**OpenMW** is a free, open source and modern engine based which reimplements and extends the one that runs the 2002 open-world RPG Morrowind. The engine comes with its own editor , called **OpenMW-CS** which allows the user to edit or create their own original games. Both OpenMW-CS and OpenMW are written from scratch and aren’t made to support any third party programs the original Morrowind engine uses to improve its functionality.
+
+**NOTE:** Playing Morrowind with this engine still requires the Morrowind data files from a copy that you own.</description>
+    <packageSourceUrl>https://github.com/ananace/chocolatey-packages/</packageSourceUrl>
+    <projectUrl>http://openmw.org</projectUrl>
+    <projectSourceUrl>https://github.com/OpenMW/openmw</projectSourceUrl>
+    <releaseNotes>https://openmw.org/2025/openmw-0-50-0-released/</releaseNotes>
+    <bugTrackerUrl>https://bugs.openmw.org/</bugTrackerUrl>
+    <tags>openmw admin game rpg</tags>
+    <licenseUrl>https://gitlab.com/OpenMW/openmw/-/raw/master/LICENSE</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <iconUrl>https://cdn.rawgit.com/ananace/chocolatey-packages/1adeb04799a706879edc60fcd65dc43dd064674b/Icons/openmw.png</iconUrl>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/Packages/OpenMW/0.50.0/tools/chocolateyinstall.ps1
+++ b/Packages/OpenMW/0.50.0/tools/chocolateyinstall.ps1
@@ -1,0 +1,19 @@
+﻿$ErrorActionPreference = 'Stop';
+
+$packageName = 'openmw'
+
+$packageArgs = @{
+  packageName    = $packageName
+  fileType       = 'exe'
+  url64bit       = 'https://github.com/OpenMW/openmw/releases/download/openmw-0.50.0/OpenMW-0.50.0-win64.exe'
+
+  checksum64     = '2c509c84fc8dbf68bdb8c11f6265689b506d26f7297e51a79e40999bab87d7c5'
+  checksumtype64 = 'sha256'
+
+  silentArgs     = "/S"
+  validExitCodes = @(0)
+
+  registryUninstallerKey = 'OpenMW 0.50.0'
+}
+
+Install-ChocolateyPackage @packageArgs

--- a/Packages/OpenMW/0.50.0/tools/chocolateyuninstall.ps1
+++ b/Packages/OpenMW/0.50.0/tools/chocolateyuninstall.ps1
@@ -1,0 +1,31 @@
+﻿$packageName = 'openmw'
+$registryUninstallerKeyName = 'OpenMW 0.50.0' #ensure this is the value in the registry
+$shouldUninstall = $true
+
+$local_key     = "HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\$registryUninstallerKeyName"
+$local_key6432   = "HKCU:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\$registryUninstallerKeyName" 
+$machine_key   = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$registryUninstallerKeyName"
+$machine_key6432 = "HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\$registryUninstallerKeyName"
+
+$file = @($local_key, $local_key6432, $machine_key, $machine_key6432) `
+    | ?{ Test-Path $_ } `
+    | Get-ItemProperty `
+    | Select-Object -ExpandProperty UninstallString
+
+if ($file -eq $null -or $file -eq '') {
+    Write-Host "$packageName has already been uninstalled by other means."
+    $shouldUninstall = $false
+}
+
+$installerType = 'EXE' 
+$silentArgs = '/S'
+$validExitCodes = @(0)
+
+if (!(Test-Path $file)) {
+    Write-Host "$packageName has already been uninstalled by other means."
+    $shouldUninstall = $false
+}
+
+if ($shouldUninstall) {
+ Uninstall-ChocolateyPackage -PackageName $packageName -FileType $installerType -SilentArgs $silentArgs -validExitCodes $validExitCodes -File $file
+}


### PR DESCRIPTION
I've not actually tested these, but we didn't change anything that should have broken, and the hashes should match as I tried for 0.48 to check I was getting the same format.